### PR TITLE
Article Sidecar POC

### DIFF
--- a/codeland.html
+++ b/codeland.html
@@ -376,7 +376,70 @@
     }
   }
 
-  /* Bigger screens  */
+  /* Article sidecar */
+
+  .codeland-article-sidecar {
+    position: fixed;
+    top: var(--header-height);
+    right: 0;
+    height: calc(100vh - var(--header-height));
+    z-index: 200;
+    transform: translateX(100vw);
+    transition: var(--transition-props);
+  }
+
+  .codeland-article-sidecar.showing {
+    transform: initial;
+  }
+
+  .codeland-article-sidecar > iframe {
+    height: 100%;
+    border: none;
+    box-shadow: -4px 0px 15px rgba(0, 0, 0, 0.1);
+    width: 100vw;
+  }
+
+  .codeland-article-sidecar > header {
+    background-color: var(--base-inverted);
+    padding: var(--su-4) var(--su-4) 0;
+    display: flex;
+    flex-direction: column;
+  }
+  .codeland-article-sidecar > header > h1 {
+    font-size: var(--fs-l);
+    font-weight: var(--fw-bold);
+  }
+  .codeland-article-sidecar > header > h2 {
+    font-size: var(--fs-base);
+    font-weight: var(--fw-normal);
+    color: var(--base-70);
+    margin-bottom: 8px;
+  }
+
+  .codeland-article-sidecar > header > button {
+    border-radius: 100%;
+    border: none;
+    width: 40px;
+    height: 40px;
+    position: absolute;
+    right: 10px;
+    top: 10px;
+    background-color: var(--base-10);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  @media screen and (min-width: 640px) {
+    .codeland-article-sidecar {
+      transform: translateX(400px);
+      transition: var(--transition-props);
+    }
+
+    .codeland-article-sidecar > iframe {
+      width: 400px;
+    }
+  }
 </style>
 
 <script>
@@ -403,6 +466,7 @@ const fetchData = url => (
 const updateTalkInfo = talkData => {
   document.querySelector('.codeland-livestream__info-title h2').textContent = `${talkData.title} by ${talkData.speaker}`;
   document.querySelector('.codeland-livestream__speaker-info div p').textContent = talkData.bio;
+  document.querySelector('.codeland-livestream__speaker-info div button').dataset.url = talkData.url;
 };
 
 // Main polling loop
@@ -466,7 +530,7 @@ poll(() => fetchData(DATA_URL), REFRESH_RATE);
             systems. She also co-hosts the Base.cs Podcast, and is a producer of the
             BaseCS and Byte Sized video series.
           </p>
-          <button class="crayons-btn crayons-btn--secondary" type="button">
+          <button class="crayons-btn crayons-btn--secondary" type="button" data-url="">
             See discussion
           </button>
         </div>
@@ -484,6 +548,18 @@ poll(() => fetchData(DATA_URL), REFRESH_RATE);
           </h2>
         </div>
       </div>
+    </div>
+
+    <div class="codeland-article-sidecar">
+      <header>
+        <h1>Discussion Article</h1>
+        <h2>Find all these articles in <a href="/t/codeland" target="_blank">#codeland</a></h2>
+        <button type="button" title="Close Article Sidecar">
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" role="img" aria-labelledby="aolcet3wgdhqhxnku7e0iw8vrv7hs8gg"><title id="aolcet3wgdhqhxnku7e0iw8vrv7hs8gg">Close moderator actions panel</title>
+            <path d="M13.172 12L8.22198 7.04999L9.63598 5.63599L16 12L9.63598 18.364L8.22198 16.95L13.172 12Z"></path>
+          </svg>
+        </button>
+      </header>
     </div>
   </section>
 
@@ -767,3 +843,35 @@ poll(() => fetchData(DATA_URL), REFRESH_RATE);
     </div>
   </section>
 </div>
+
+<script>
+  const articleButt = document.querySelector('.codeland-livestream__speaker-info div button');
+  const closeButt = document.querySelector('.codeland-article-sidecar header button');
+  const sidecarDiv = document.querySelector('.codeland-article-sidecar');
+
+  function removeSidecarIframe() {
+    const sidecarEmbed = sidecarDiv.querySelector('iframe');
+    if (sidecarEmbed !== null) {
+      sidecarDiv.removeChild(sidecarEmbed);
+    }
+  };
+
+  // EventListener to open the Article Sidecar
+  articleButt.addEventListener('click', () => {
+    if (sidecarDiv.classList.contains('showing')) { return }
+
+    // Create iframe using current discussion article
+    const sidecar = document.createElement("iframe");
+    sidecar.setAttribute("src", articleButt.dataset.url);
+
+    removeSidecarIframe();
+    sidecarDiv.appendChild(sidecar);
+    sidecarDiv.classList.toggle('showing');
+  });
+
+  // EventListener to hide the Article Sidecar
+  closeButt.addEventListener('click', () => {
+    removeSidecarIframe();
+    sidecarDiv.classList.toggle('showing');
+  });
+</script>


### PR DESCRIPTION
This a first working version of the Article Sidecar (side panel). It's very much based on the recently released Moderator Tool. It's also expecting to find an Article URL in the button fetched from the dynamic data.

A very important feature that we will need is comment reload. A suggestion from Ben is implementing the feature in the site itself. This can be a big undertaking to code & release on time, but the great benefit is that the entire site would benefit from it!

An alternative (hacky) solution I have in mind is to manually fetch the comments/article endpoint from our API and counting the total number of comments the article has. If the number varies we can trigger an iframe reload. The request load on the API could be mitigated in a few different ways, but open to hear what we think about this.

There's a lot of things than can be improved visually too, but here are some GIFs to see it in action:

![sidecar-1-720](https://user-images.githubusercontent.com/6045239/84330274-3267a300-ab44-11ea-8e1b-af5b91dafcde.gif)

 

![sidecar-1-720-3](https://user-images.githubusercontent.com/6045239/84330660-3c3dd600-ab45-11ea-92ad-0757792f6617.gif)

