### PR TITLE
Add interactive elements

### DIFF
--- a/codeland.html
+++ b/codeland.html
@@ -359,6 +359,28 @@
     }
   }
 
+  .codeland-sponsors__logo-wrapper {
+    position: relative;
+    display: flex;
+    background: red;
+    width: 100%;
+    height: 240px;
+    transition: all var(--transition-props);
+  }
+
+
+  .codeland-sponsors__logo-wrapper:hover:after {
+    align-items: center;
+    background: rgba(0,0,0,0.15);
+    color: var(--base-inverted);
+    content: "View booth";
+    display: flex;
+    height: 100%;
+    justify-content: center;
+    position: absolute;
+    width: 100%;
+  }
+
   .codeland-sponsors__platinum .codeland-sponsors__logo-wrapper {
       height: 240px;
   }
@@ -377,12 +399,6 @@
     .codeland-sponsors__mentor {
       grid-template-columns: repeat(4, 1fr);
     }
-  }
-
-  .codeland-sponsors__logo-wrapper {
-    background: red;
-    width: 100%;
-    height: 240px;
   }
 
   @media screen and (min-width: 640px) {
@@ -875,24 +891,16 @@ document.addEventListener("DOMContentLoaded", function() {
       </div>
       <div class="codeland-sponsors__mentor">
         <a href="" class="codeland-sponsors__logo-wrapper">
-          <figure>
-            <img class="codeland-sponsors__logo" src="" />
-          </figure>
+          <img class="codeland-sponsors__logo" src="" />
         </a>
         <a href="" class="codeland-sponsors__logo-wrapper">
-          <figure>
-            <img class="codeland-sponsors__logo" src="" />
-          </figure>
+          <img class="codeland-sponsors__logo" src="" />
         </a>
         <a href="" class="codeland-sponsors__logo-wrapper">
-          <figure>
-            <img class="codeland-sponsors__logo" src="" />
-          </figure>
+          <img class="codeland-sponsors__logo" src="" />
         </a>
         <a href="" class="codeland-sponsors__logo-wrapper">
-          <figure>
-            <img class="codeland-sponsors__logo" src="" />
-          </figure>
+          <img class="codeland-sponsors__logo" src="" />
         </a>
       </div>
     </div>

--- a/codeland.html
+++ b/codeland.html
@@ -151,7 +151,7 @@
 
   .codeland-livestream__speaker-info {
     order: 3;
-    overflow-y: scroll;
+    overflow-y: auto;
     position: relative;
   }
 
@@ -522,7 +522,7 @@
 
   @media screen and (min-width: 640px) {
     .codeland-sidecar {
-      transform: translateX(400px);
+      transform: translateX(415px);
       transition: var(--transition-props);
     }
 

--- a/codeland.html
+++ b/codeland.html
@@ -153,6 +153,24 @@
     }
   }
 
+  .codeland-livestream__info-state {
+    color: var(--base-70);
+  }
+
+  .codeland-livestream__info-link {
+    color: var(--body-color);
+  }
+
+  .codeland-livestream__info-link:hover {
+    color: var(--link-brand-color);
+    fill: var(--link-brand-color);
+  }
+
+  .codeland-livestream__info-link:hover .codeland-livestream__info-title,
+  .codeland-livestream__info-link:hover .codeland-livestream__info-helper span {
+    text-decoration: underline;
+  }
+
   .codeland-livestream__info-title {
     display: block;
     width: 100%;
@@ -164,14 +182,14 @@
       justify-content: space-between;
     }
   }
-
-  .codeland-livestream__info-helper {
+.codeland-livestream__info-helper {
     display: none;
   }
 
   @media screen and (min-width: 768px) {
     .codeland-livestream__info-helper {
-      display: inherit;
+      display: flex;
+      align-items: center;
     }
   }
 
@@ -678,19 +696,24 @@ document.addEventListener("DOMContentLoaded", function() {
           </button>
         </div>
       </aside>
-      <div class="codeland-livestream__info">
-        <span class="ff-accent fs-base">
-          Currently
-        </span>
-        <div class="codeland-livestream__info-title">
-          <h2>
-            The Cost of Data by Vaidehi Joshi
-          </h2>
-          <h2 class="codeland-livestream__info-helper fw-normal">
-            View Info
-          </h2>
+      <a href="" class="codeland-livestream__info-link">
+        <div class="codeland-livestream__info">
+          <span class="codeland-livestream__info-state ff-accent fs-base">
+            Currently
+          </span>
+          <div class="codeland-livestream__info-title">
+            <h2>
+              The Cost of Data by Vaidehi Joshi
+            </h2>
+            <h2 class="codeland-livestream__info-helper fw-normal">
+              <span>
+                View Info
+              </span>
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="32" height="32"><path fill="none" d="M0 0h24v24H0z"/><path d="M16.172 11l-5.364-5.364 1.414-1.414L20 12l-7.778 7.778-1.414-1.414L16.172 13H4v-2z"/></svg>
+            </h2>
+          </div>
         </div>
-      </div>
+      </a>
     </div>
 
     <div class="codeland-sidecar">

--- a/codeland.html
+++ b/codeland.html
@@ -215,6 +215,34 @@
     flex-grow: 1;
   }
 
+  .codeland-schedule__event-link {
+    color: var(--base-inverted);
+    display: block;
+  }
+
+
+  .codeland-schedule__event-view-link {
+    display: none;
+    transition: all var(--transition-props);
+    tranform: translateX(0);
+  }
+
+  @media screen and (min-width: 768px) {
+
+    .codeland-schedule__event-link:hover .codeland-schedule__event-view-link {
+        fill: var(--base-inverted);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        tranform: translateX(-8px);
+    }
+
+    .codeland-schedule__event-link:hover .codeland-schedule__event-description {
+      opacity: 0.8;
+    }
+  }
+
+
   .codeland-schedule__event {
     display: block;
     margin-bottom: var(--su-5);
@@ -244,7 +272,7 @@
   }
 
   .codeland-schedule__event-description {
-    opacity: 0.8;
+    opacity: 0.6;
   }
 
   /****** SPONSORS *******/
@@ -703,63 +731,78 @@ document.addEventListener("DOMContentLoaded", function() {
           </p>
         </div>
       </div>
-      <div class="codeland-schedule__event">
-        <div class="codeland-schedule__event-metadata fs-s s:fs-base">
-          10 AM - 10:20 AM UTC
+      <a href="" class="codeland-schedule__event-link">
+        <div class="codeland-schedule__event">
+          <div class="codeland-schedule__event-metadata fs-s s:fs-base">
+            10 AM - 10:20 AM UTC
+          </div>
+          <div class="codeland-schedule__event-info">
+            <h3>
+              Scott Hanselman (keynote)
+            </h3>
+            <h4 class="codeland-schedule__event-title">
+              The History of Computer Science
+            </h4>
+            <p class="codeland-schedule__event-description fs-base m:fs-l">
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+              eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+              ad minim veniam, quis nostrud exercitation t dolore magna aliqua. Ut
+              enim ad minim veniam, quis nostrud exercitation  
+            </p>
+          </div>
+          <div class="codeland-schedule__event-view-link">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="48" height="48"><path fill="none" d="M0 0h24v24H0z"/><path d="M16.172 11l-5.364-5.364 1.414-1.414L20 12l-7.778 7.778-1.414-1.414L16.172 13H4v-2z"/></svg>
+          </div>
         </div>
-        <div class="codeland-schedule__event-info">
-          <h3>
-            Scott Hanselman (keynote)
-          </h3>
-          <h4 class="codeland-schedule__event-title">
-            The History of Computer Science
-          </h4>
-          <p class="codeland-schedule__event-description fs-base m:fs-l">
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
-            ad minim veniam, quis nostrud exercitation t dolore magna aliqua. Ut
-            enim ad minim veniam, quis nostrud exercitation  
-          </p>
+      </a>
+      <a href="" class="codeland-schedule__event-link">
+        <div class="codeland-schedule__event">
+          <div class="codeland-schedule__event-metadata fs-s s:fs-base">
+            10 AM - 10:20 AM UTC
+          </div>
+          <div class="codeland-schedule__event-info">
+            <h3>
+              Gargi Sharma
+            </h3>
+            <h4 class="codeland-schedule__event-title">
+              Printing floating point numbers is surprisingly hard!
+            </h4>
+            <p class="codeland-schedule__event-description fs-base m:fs-l">
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+              eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+              ad minim veniam, quis nostrud exercitation t dolore magna aliqua. Ut
+              enim ad minim veniam, quis nostrud exercitation  
+            </p>
+          </div>
+          <div class="codeland-schedule__event-view-link">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="48" height="48"><path fill="none" d="M0 0h24v24H0z"/><path d="M16.172 11l-5.364-5.364 1.414-1.414L20 12l-7.778 7.778-1.414-1.414L16.172 13H4v-2z"/></svg>
+          </div>
         </div>
-      </div>
-      <div class="codeland-schedule__event">
-        <div class="codeland-schedule__event-metadata fs-s s:fs-base">
-          10 AM - 10:20 AM UTC
+      </a>
+      <a href="" class="codeland-schedule__event-link">
+        <div class="codeland-schedule__event">
+          <div class="codeland-schedule__event-metadata fs-s s:fs-base">
+            10 AM - 10:20 AM UTC
+          </div>
+          <div class="codeland-schedule__event-info">
+            <h3>
+              Brian Vermeer
+            </h3>
+            <h4 class="codeland-schedule__event-title">
+              Live Exploiting Your OS Dependencies
+            </h4>
+            <p class="codeland-schedule__event-description fs-base m:fs-l">
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+              eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+              ad minim veniam, quis nostrud exercitation t dolore magna aliqua. Ut
+              enim ad minim veniam, quis nostrud exercitation  
+            </p>
+          </div>
+          <div class="codeland-schedule__event-view-link">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="48" height="48"><path fill="none" d="M0 0h24v24H0z"/><path d="M16.172 11l-5.364-5.364 1.414-1.414L20 12l-7.778 7.778-1.414-1.414L16.172 13H4v-2z"/></svg>
+          </div>
         </div>
-        <div class="codeland-schedule__event-info">
-          <h3>
-            Gargi Sharma
-          </h3>
-          <h4 class="codeland-schedule__event-title">
-            Printing floating point numbers is surprisingly hard!
-          </h4>
-          <p class="codeland-schedule__event-description fs-base m:fs-l">
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
-            ad minim veniam, quis nostrud exercitation t dolore magna aliqua. Ut
-            enim ad minim veniam, quis nostrud exercitation  
-          </p>
-        </div>
-      </div>
-      <div class="codeland-schedule__event">
-        <div class="codeland-schedule__event-metadata fs-s s:fs-base">
-          10 AM - 10:20 AM UTC
-        </div>
-        <div class="codeland-schedule__event-info">
-          <h3>
-            Brian Vermeer
-          </h3>
-          <h4 class="codeland-schedule__event-title">
-            Live Exploiting Your OS Dependencies
-          </h4>
-          <p class="codeland-schedule__event-description fs-base m:fs-l">
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
-            ad minim veniam, quis nostrud exercitation t dolore magna aliqua. Ut
-            enim ad minim veniam, quis nostrud exercitation  
-          </p>
-        </div>
-      </div>
+      </a>
     </div>
   </section>
 

--- a/codeland.html
+++ b/codeland.html
@@ -3,6 +3,7 @@
   .codeland-content {
     position: sticky;
     height: 100%;
+    overflow-x: hidden;
   }
 
   .codeland-content__container {
@@ -123,6 +124,12 @@
     }
   }
 
+  @media screen and (min-width: 1024px) {
+    .codeland-livestream__container {
+      grid-template-rows: 500px;
+    }
+  }
+
   @media screen and (min-width: 1280px) {
     .codeland-livestream__container {
       width: var(--site-width);
@@ -144,13 +151,28 @@
 
   .codeland-livestream__speaker-info {
     order: 3;
-    overflow-x: scroll;
+    overflow-y: scroll;
+    position: relative;
   }
 
   @media screen and (min-width: 640px) {
     .codeland-livestream__speaker-info {
       order: inherit;
     }
+  }
+
+  .codeland-livestream__speaker-info__footer {
+    background: var(--base-inverted);
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    padding: var(--su-3);
+    box-shadow: 0 -1px 1px var(--header-shadow);
   }
 
   .codeland-livestream__info-state {
@@ -691,9 +713,11 @@ document.addEventListener("DOMContentLoaded", function() {
             systems. She also co-hosts the Base.cs Podcast, and is a producer of the
             BaseCS and Byte Sized video series.
           </p>
-          <button class="crayons-btn crayons-btn--secondary" type="button" data-url="">
-            See discussion
-          </button>
+          <div class="codeland-livestream__speaker-info__footer">
+            <button class="crayons-btn crayons-btn--secondary w-100" type="button" data-url="">
+              See discussion
+            </button>
+          </div>
         </div>
       </aside>
       <a href="" class="codeland-livestream__info-link">


### PR DESCRIPTION
- Convert the current talk’s “View Info” area into a link that opens up the article panel.
- Convert the schedule items into links that open up the article panel.
- Pin the “See Discussion” CTA in the livestream sidebar so that it’s always visible.
- Convert the sponsor images’ placeholders into links that open up the article panel.
- Add `overflow-x: hidden` on container to prevent unnecessary horizontal scroll.

See video here: https://share.getcloudapp.com/jkuQZ6DO