### PR TITLE
First working version of comment refresh

### DIFF
--- a/codeland.html
+++ b/codeland.html
@@ -968,9 +968,23 @@ document.addEventListener("DOMContentLoaded", function() {
   const sidecarSubtitle = sidecarDiv.querySelector('header h2');
   const iframe = sidecarDiv.querySelector('iframe');
 
-  function presentSidecar(url, title, subtitle) {
+  const COMMENT_REFRESH_RATE = 45000;
+  let articleRefreshId = null;
+  let articleCommentCount = -1;
+
+  const presentSidecar = (url, title, subtitle, watchComments = false) => {
     if (!sidecarDiv.classList.contains('showing')) {
       sidecarDiv.classList.toggle('showing');
+    }
+
+    if (watchComments) {
+      iframe.onload = function() {
+        articleRefreshId = iframe.contentDocument.getElementById('article-body').dataset.articleId;
+      }
+    } else {
+      articleRefreshId = null;
+      articleCommentCount = -1;
+      iframe.onload = null;
     }
 
     if (iframe.src !== url) {
@@ -986,7 +1000,8 @@ document.addEventListener("DOMContentLoaded", function() {
     presentSidecar(
       livestreamButt.dataset.url,
       'Discussion Article',
-      'Find all these articles in <a href="/t/codeland" target="_blank">#codeland</a>'
+      'Find all these articles in <a href="/t/codeland" target="_blank">#codeland</a>',
+      true
     );
   });
 
@@ -1008,4 +1023,34 @@ document.addEventListener("DOMContentLoaded", function() {
       );
     });
   });
+
+  const checkCommentCount = (obj) => {
+    if (Array.isArray(obj)) {
+      return obj.reduce((acumulator, comment) => acumulator + checkCommentCount(comment), 0);
+    } else {
+      return 1 + obj.children.reduce((acumulator, comment) => acumulator + checkCommentCount(obj.children), 0);
+    }
+  }
+
+  const checkUpdatedComments = () => {
+    if (articleRefreshId === null) {
+      return Promise.resolve();
+    }
+
+    return fetch(`/api/comments?a_id=${articleRefreshId}`)
+      .then((resp) => resp.json())
+      .then(function(data) {
+          let newCount = checkCommentCount(data);
+          // The first time we fetch the comment count we don't want a refresh
+          // hence the -1 check :)
+          if (articleCommentCount > -1 && newCount !== articleCommentCount) {
+            iframe.contentDocument.location.reload(true)
+          }
+          articleCommentCount = newCount;
+          console.log("Count", articleCommentCount);
+      })
+  }
+
+  // Article comment sync polling loop
+  poll(() => checkUpdatedComments(), COMMENT_REFRESH_RATE);
 </script>

--- a/codeland.html
+++ b/codeland.html
@@ -676,7 +676,7 @@ document.addEventListener("DOMContentLoaded", function() {
 
 </script>
 
-<div class="codeland-content">
+<div class="codeland-content" data-no-instant>
   <header id="codeland-header">
     <div class="codeland-header__container">
       <figure>
@@ -1070,7 +1070,13 @@ document.addEventListener("DOMContentLoaded", function() {
   let articleRefreshId = null;
   let articleCommentCount = -1;
 
-  const presentSidecar = (url, title, subtitle, watchComments = false) => {
+  const presentSidecar = (url, title, subtitle, watchComments = true) => {
+    var userStatus = document.body.getAttribute('data-user-status');
+    if (userStatus === 'logged-out') {
+      window.open(url, '_blank');
+      return;
+    }
+
     if (!sidecarDiv.classList.contains('showing')) {
       sidecarDiv.classList.toggle('showing');
     }
@@ -1098,8 +1104,7 @@ document.addEventListener("DOMContentLoaded", function() {
     presentSidecar(
       livestreamButt.dataset.url,
       'Discussion Article',
-      'Find all these articles in <a href="/t/codeland" target="_blank">#codeland</a>',
-      true
+      'Find all these articles in <a href="/t/codeland" target="_blank">#codeland</a>'
     );
   });
 
@@ -1110,19 +1115,46 @@ document.addEventListener("DOMContentLoaded", function() {
     }
   });
 
-  // EventListener for all Social Corner chat rooms
+  // Reusable Event Callbacks for each section
+  const socialCornerClick = (event) => {
+    presentSidecar(
+      event.target.dataset.url,
+      'Social Corner',
+      'Find all these articles in <a href="/t/codeland" target="_blank">#codeland</a>',
+      false
+    );
+  }
+  const scheduleClick = (event) => {
+    event.preventDefault();
+    presentSidecar(
+      event.target.href,
+      'Discussion Article',
+      'Find all these articles in <a href="/t/codeland" target="_blank">#codeland</a>'
+    );
+  }
+  const sponsorBoothClick = (event) => {
+    event.preventDefault();
+    presentSidecar(
+      event.target.href,
+      'Sponsor booth',
+      'Find all these articles in <a href="/t/codeland" target="_blank">#codeland</a>'
+    );
+  }
+
+  // Adds EventListeners to links in each section
   const socialCorner = document.getElementById('codeland-social-corner');
   socialCorner.querySelectorAll('button').forEach(button => {
-    button.addEventListener('click', (event) => {
-      presentSidecar(
-        event.target.dataset.url,
-        'Social Corner',
-        'Powered by <a href="/connect" target="_blank">Connect</a>'
-      );
-    });
+    button.addEventListener('click', socialCornerClick);
+  });
+  document.querySelectorAll('.codeland-schedule__event-link').forEach(link => {
+    link.addEventListener('click', scheduleClick);
+  });
+  document.querySelectorAll('.codeland-sponsors__logo-wrapper').forEach(link => {
+    link.addEventListener('click', sponsorBoothClick);
   });
 
-  // Comments come in a tree structure so this method recursively counts them
+
+  // Comments come in a tree structure so this method counts them recursively
   const checkCommentCount = (obj) => {
     if (Array.isArray(obj)) {
       return obj.reduce((total, comment) => total + checkCommentCount(comment), 0);

--- a/codeland.html
+++ b/codeland.html
@@ -978,7 +978,7 @@ document.addEventListener("DOMContentLoaded", function() {
     }
 
     if (watchComments) {
-      iframe.onload = function() {
+      iframe.onload = () => {
         articleRefreshId = iframe.contentDocument.getElementById('article-body').dataset.articleId;
       }
     } else {
@@ -1024,11 +1024,14 @@ document.addEventListener("DOMContentLoaded", function() {
     });
   });
 
+  // Comments come in a tree structure so this method recursively counts them
   const checkCommentCount = (obj) => {
     if (Array.isArray(obj)) {
-      return obj.reduce((acumulator, comment) => acumulator + checkCommentCount(comment), 0);
+      return obj.reduce((total, comment) => total + checkCommentCount(comment), 0);
+    } else if (obj.children != undefined && obj.children.length > 0) {
+      return 1 + checkCommentCount(obj.children);
     } else {
-      return 1 + obj.children.reduce((acumulator, comment) => acumulator + checkCommentCount(obj.children), 0);
+      return 1;
     }
   }
 
@@ -1041,13 +1044,11 @@ document.addEventListener("DOMContentLoaded", function() {
       .then((resp) => resp.json())
       .then(function(data) {
           let newCount = checkCommentCount(data);
-          // The first time we fetch the comment count we don't want a refresh
-          // hence the -1 check :)
+          // The first time we fetch the comment count we don't want a refresh hence the -1 check :)
           if (articleCommentCount > -1 && newCount !== articleCommentCount) {
             iframe.contentDocument.location.reload(true)
           }
           articleCommentCount = newCount;
-          console.log("Count", articleCommentCount);
       })
   }
 


### PR DESCRIPTION
Changes `presentSidecar` function to ES6 format for consistency & first working version of comment reload using API.

I'd want to improve this a bit but curious to see if this is something we want to keep if we don't have time to implement proper comment reload for articles site-wide.