### PR TITLE
Schedule section

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ _codeland.html_: code for the main CodeLand landing page
 
 _banner.html_: code for the home page hero banner 
 
-_data.json_: sample data format for dynamic data updates on _codeland.html_
+codeland_now_playing.json_: sample data format for dynamic data updates on _codeland.html_
+
+codeland_schedule.json_: sample data for the programming schedule on _codeland.html_ 
 
 _display_ad.html_: code for the display ad/sidebar section on the homepage
 

--- a/codeland.html
+++ b/codeland.html
@@ -549,19 +549,32 @@
 </style>
 
 <script>
-const DATA_URL = "/page/codeland_data";
-const REFRESH_RATE = 15000;
+const NOW_PLAYING_DATA_URL = "/page/codeland_now_playing";
+const NOW_PLAYING_REFRESH_RATE = 15000;
+const SCHEDULE_DATA_URL = "/page/codeland_schedule";
+const SCHEDULE_REFRESH_RATE = 120000;
 
 const sleep = time => new Promise(resolve => setTimeout(resolve, time));
 const poll = (promiseFn, time) => promiseFn()
               .then(sleep(time)
               .then(() => poll(promiseFn, time)));
 
-const fetchData = url => (
+const fetchNowPlayingData = url => (
   fetch(url)
     .then((resp) => resp.json())
     .then(function(data) {
-        updateTalkInfo(data.talk);
+        updateTalkInfo(data.now_playing);
+    })
+    .catch(function(error) {
+        console.log(error);
+    })
+);
+
+const fetchScheduleData = url => (
+  fetch(url)
+    .then((resp) => resp.json())
+    .then(function(data) {
+        updateScheduleInfo(data.schedule);
     })
     .catch(function(error) {
         console.log(error);
@@ -575,8 +588,22 @@ const updateTalkInfo = talkData => {
   document.querySelector('.codeland-livestream__speaker-info div button').dataset.url = talkData.url;
 };
 
+const updateScheduleInfo = scheduleData => {
+  document.querySelectorAll('.codeland-content__container .codeland-schedule__event').forEach(element => {
+    element.remove();
+  });
+  var listing_container = document.querySelector('.codeland-content__container');
+  var template = document.querySelector('#schedule-entry-template');
+  scheduleData.forEach(data => {
+    var listing = template.content.cloneNode(true);
+    listing.querySelector('.codeland-schedule__event-title').innerHTML = data.title;
+    listing_container.append(listing);
+  });
+}
+
 // Main polling loop
-poll(() => fetchData(DATA_URL), REFRESH_RATE);
+poll(() => fetchNowPlayingData(NOW_PLAYING_DATA_URL), NOW_PLAYING_REFRESH_RATE);
+poll(() => fetchScheduleData(SCHEDULE_DATA_URL), SCHEDULE_REFRESH_RATE);
 
 // Nav menu
 document.addEventListener("DOMContentLoaded", function() {
@@ -631,10 +658,6 @@ document.addEventListener("DOMContentLoaded", function() {
   ]
 
   function updateItem() {
-    console.log(codelandSections);
-    console.log(codelandSections[0]);
-    console.log(codelandSections.length - 1);
-
     for (let i = 0; i < (codelandSections.length - 1); i++) {
       if ( (window.scrollY >= codelandSections[i].offsetTop) && (window.scrollY <=
         (codelandSections[i].offsetTop + codelandSections[i].offsetHeight))) {
@@ -1057,6 +1080,17 @@ document.addEventListener("DOMContentLoaded", function() {
     </div>
   </section>
 </div>
+
+<template id="schedule-entry-template">
+  <div class="codeland-schedule__event">
+    <div class="codeland-schedule__event-metadata fs-s s:fs-base"></div>
+    <div class="codeland-schedule__event-info">
+      <h3></h3>
+      <h4 class="codeland-schedule__event-title"></h4>
+      <p class="codeland-schedule__event-description fs-base m:fs-l"></p>
+    </div>
+  </div>
+</template>
 
 <script>
   const livestreamButt = document.querySelector('.codeland-livestream__speaker-info div button');

--- a/codeland.html
+++ b/codeland.html
@@ -613,6 +613,7 @@ const updateScheduleInfo = scheduleData => {
     listing.querySelector('.codeland-schedule__event-info h3').innerHTML = data.speaker;
     listing.querySelector('.codeland-schedule__event-title').innerHTML = data.title;
     listing.querySelector('.codeland-schedule__event-speaker-bio').innerHTML = data.bio;
+    listing.querySelector('a.codeland-schedule__event-link').href = data.url;
     listing_container.append(listing);
   });
 }

--- a/codeland.html
+++ b/codeland.html
@@ -558,6 +558,8 @@ const NOW_PLAYING_REFRESH_RATE = 15000;
 const SCHEDULE_DATA_URL = "/page/codeland_schedule";
 const SCHEDULE_REFRESH_RATE = 120000;
 
+var scheduleData;
+
 const sleep = time => new Promise(resolve => setTimeout(resolve, time));
 const poll = (promiseFn, time) => promiseFn()
               .then(sleep(time)
@@ -567,7 +569,7 @@ const fetchNowPlayingData = url => (
   fetch(url)
     .then((resp) => resp.json())
     .then(function(data) {
-        updateTalkInfo(data.now_playing);
+        updateTalkInfo(data.now_playing.talk_id);
     })
     .catch(function(error) {
         console.log(error);
@@ -578,7 +580,8 @@ const fetchScheduleData = url => (
   fetch(url)
     .then((resp) => resp.json())
     .then(function(data) {
-        updateScheduleInfo(data.schedule);
+        scheduleData = data.schedule;
+        updateScheduleInfo(scheduleData);
     })
     .catch(function(error) {
         console.log(error);
@@ -586,7 +589,9 @@ const fetchScheduleData = url => (
 );
 
 // Update the contents of a div with new data
-const updateTalkInfo = talkData => {
+const updateTalkInfo = talkId => {
+  talkData = scheduleData.find(element => element.id === talkId);
+
   document.querySelector('.codeland-livestream__info-title h2').textContent = `${talkData.title} by ${talkData.speaker}`;
   document.querySelector('.codeland-livestream__speaker-info div p').innerHTML = talkData.bio;
   document.querySelector('.codeland-livestream__speaker-info div button').dataset.url = talkData.url;
@@ -611,6 +616,9 @@ const updateScheduleInfo = scheduleData => {
     listing_container.append(listing);
   });
 }
+
+//one time initial data load
+fetchScheduleData(SCHEDULE_DATA_URL);
 
 // Main polling loop
 poll(() => fetchScheduleData(SCHEDULE_DATA_URL), SCHEDULE_REFRESH_RATE);

--- a/codeland.html
+++ b/codeland.html
@@ -315,6 +315,10 @@
     opacity: 0.6;
   }
 
+  .codeland-schedule__event-speaker-bio {
+    display: none;
+  }
+
   /****** SPONSORS *******/
 
   #codeland-sponsors {
@@ -595,15 +599,23 @@ const updateScheduleInfo = scheduleData => {
   var listing_container = document.querySelector('.codeland-content__container');
   var template = document.querySelector('#schedule-entry-template');
   scheduleData.forEach(data => {
+    var start_time = new Date(Date.parse(data.start_time));
+    var end_time = new Date(Date.parse(data.end_time));
+
     var listing = template.content.cloneNode(true);
+    listing.querySelector('.codeland-schedule__event').setAttribute("data-event-id", data.id);
+    listing.querySelector('.codeland-schedule__event-metadata').innerHTML = `${start_time.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })} - ${end_time.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })} `;
+    listing.querySelector('.codeland-schedule__event-info h3').innerHTML = data.speaker;
     listing.querySelector('.codeland-schedule__event-title').innerHTML = data.title;
+    listing.querySelector('.codeland-schedule__event-speaker-bio').innerHTML = data.bio;
     listing_container.append(listing);
   });
 }
 
 // Main polling loop
-poll(() => fetchNowPlayingData(NOW_PLAYING_DATA_URL), NOW_PLAYING_REFRESH_RATE);
 poll(() => fetchScheduleData(SCHEDULE_DATA_URL), SCHEDULE_REFRESH_RATE);
+poll(() => fetchNowPlayingData(NOW_PLAYING_DATA_URL), NOW_PLAYING_REFRESH_RATE);
+
 
 // Nav menu
 document.addEventListener("DOMContentLoaded", function() {
@@ -801,94 +813,6 @@ document.addEventListener("DOMContentLoaded", function() {
           Schedule & agenda
         </h2>
       </header>
-      <div class="codeland-schedule__event">
-        <div class="codeland-schedule__event-metadata fs-s s:fs-base">
-          10 AM - 10:20 AM UTC
-        </div>
-        <div class="codeland-schedule__event-info">
-          <h3>
-            Welcome Address
-          </h3>
-          <p class="codeland-schedule__event-description fs-base m:fs-l">
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
-            ad minim veniam, quis nostrud exercitation t dolore magna aliqua. Ut
-            enim ad minim veniam, quis nostrud exercitation  
-          </p>
-        </div>
-      </div>
-      <a href="" class="codeland-schedule__event-link">
-        <div class="codeland-schedule__event">
-          <div class="codeland-schedule__event-metadata fs-s s:fs-base">
-            10 AM - 10:20 AM UTC
-          </div>
-          <div class="codeland-schedule__event-info">
-            <h3>
-              Scott Hanselman (keynote)
-            </h3>
-            <h4 class="codeland-schedule__event-title">
-              The History of Computer Science
-            </h4>
-            <p class="codeland-schedule__event-description fs-base m:fs-l">
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-              eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
-              ad minim veniam, quis nostrud exercitation t dolore magna aliqua. Ut
-              enim ad minim veniam, quis nostrud exercitation  
-            </p>
-          </div>
-          <div class="codeland-schedule__event-view-link">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="48" height="48"><path fill="none" d="M0 0h24v24H0z"/><path d="M16.172 11l-5.364-5.364 1.414-1.414L20 12l-7.778 7.778-1.414-1.414L16.172 13H4v-2z"/></svg>
-          </div>
-        </div>
-      </a>
-      <a href="" class="codeland-schedule__event-link">
-        <div class="codeland-schedule__event">
-          <div class="codeland-schedule__event-metadata fs-s s:fs-base">
-            10 AM - 10:20 AM UTC
-          </div>
-          <div class="codeland-schedule__event-info">
-            <h3>
-              Gargi Sharma
-            </h3>
-            <h4 class="codeland-schedule__event-title">
-              Printing floating point numbers is surprisingly hard!
-            </h4>
-            <p class="codeland-schedule__event-description fs-base m:fs-l">
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-              eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
-              ad minim veniam, quis nostrud exercitation t dolore magna aliqua. Ut
-              enim ad minim veniam, quis nostrud exercitation  
-            </p>
-          </div>
-          <div class="codeland-schedule__event-view-link">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="48" height="48"><path fill="none" d="M0 0h24v24H0z"/><path d="M16.172 11l-5.364-5.364 1.414-1.414L20 12l-7.778 7.778-1.414-1.414L16.172 13H4v-2z"/></svg>
-          </div>
-        </div>
-      </a>
-      <a href="" class="codeland-schedule__event-link">
-        <div class="codeland-schedule__event">
-          <div class="codeland-schedule__event-metadata fs-s s:fs-base">
-            10 AM - 10:20 AM UTC
-          </div>
-          <div class="codeland-schedule__event-info">
-            <h3>
-              Brian Vermeer
-            </h3>
-            <h4 class="codeland-schedule__event-title">
-              Live Exploiting Your OS Dependencies
-            </h4>
-            <p class="codeland-schedule__event-description fs-base m:fs-l">
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-              eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
-              ad minim veniam, quis nostrud exercitation t dolore magna aliqua. Ut
-              enim ad minim veniam, quis nostrud exercitation  
-            </p>
-          </div>
-          <div class="codeland-schedule__event-view-link">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="48" height="48"><path fill="none" d="M0 0h24v24H0z"/><path d="M16.172 11l-5.364-5.364 1.414-1.414L20 12l-7.778 7.778-1.414-1.414L16.172 13H4v-2z"/></svg>
-          </div>
-        </div>
-      </a>
     </div>
   </section>
 
@@ -1082,14 +1006,25 @@ document.addEventListener("DOMContentLoaded", function() {
 </div>
 
 <template id="schedule-entry-template">
-  <div class="codeland-schedule__event">
-    <div class="codeland-schedule__event-metadata fs-s s:fs-base"></div>
-    <div class="codeland-schedule__event-info">
-      <h3></h3>
-      <h4 class="codeland-schedule__event-title"></h4>
-      <p class="codeland-schedule__event-description fs-base m:fs-l"></p>
+  <a href="" class="codeland-schedule__event-link">
+    <div class="codeland-schedule__event" data-event-id="">
+      <div class="codeland-schedule__event-metadata fs-s s:fs-base">
+        10 AM - 10:20 AM UTC
+      </div>
+      <div class="codeland-schedule__event-info">
+        <h3>
+          Gargi Sharma
+        </h3>
+        <h4 class="codeland-schedule__event-title">
+          Printing floating point numbers is surprisingly hard!
+        </h4>
+        <div class="codeland-schedule__event-speaker-bio"></div>
+      </div>
+      <div class="codeland-schedule__event-view-link">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="48" height="48"><path fill="none" d="M0 0h24v24H0z"/><path d="M16.172 11l-5.364-5.364 1.414-1.414L20 12l-7.778 7.778-1.414-1.414L16.172 13H4v-2z"/></svg>
+      </div>
     </div>
-  </div>
+  </a>
 </template>
 
 <script>

--- a/codeland.html
+++ b/codeland.html
@@ -264,7 +264,7 @@
   .codeland-schedule__event-view-link {
     display: none;
     transition: all var(--transition-props);
-    tranform: translateX(0);
+    transform: translateX(0);
   }
 
   @media screen and (min-width: 768px) {
@@ -274,7 +274,7 @@
         display: flex;
         justify-content: center;
         align-items: center;
-        tranform: translateX(-8px);
+        transform: translateX(-8px);
     }
 
     .codeland-schedule__event-link:hover .codeland-schedule__event-description {

--- a/codeland_now_playing.json
+++ b/codeland_now_playing.json
@@ -1,5 +1,5 @@
 {
-  "talk": {  
+  "now_playing": {  
       "speaker": "Vaidehi Joshi",   
       "title": "The Cost of Data",   
       "bio": "<strong>Vaidehi Joshi</strong> is a senior engineer at DEV, where she builds community and helps improve the software careers of millions. She enjoys building and breaking code, but loves creating empathetic engineering teams a whole lot more. She is the creator of basecs and baseds, two writing series exploring the fundamentals of computer science and distributed systems. She also co-hosts the Base.cs Podcast, and is a producer of the BaseCS and Byte Sized video series.",

--- a/codeland_now_playing.json
+++ b/codeland_now_playing.json
@@ -1,8 +1,5 @@
 {
   "now_playing": {  
-      "speaker": "Vaidehi Joshi",   
-      "title": "The Cost of Data",   
-      "bio": "<strong>Vaidehi Joshi</strong> is a senior engineer at DEV, where she builds community and helps improve the software careers of millions. She enjoys building and breaking code, but loves creating empathetic engineering teams a whole lot more. She is the creator of basecs and baseds, two writing series exploring the fundamentals of computer science and distributed systems. She also co-hosts the Base.cs Podcast, and is a producer of the BaseCS and Byte Sized video series.",
-      "url": "https://dev.to/discussion-article"
+      "talk_id": 1
   }  
 }

--- a/codeland_schedule.json
+++ b/codeland_schedule.json
@@ -1,0 +1,22 @@
+{
+  "schedule": [
+    {
+      "id": 1,
+      "start_time": "July 23, 2020 10:00:00 UTC",
+      "end_time": "July 23, 2020 10:20:00 UTC",
+      "speaker": "Vaidehi Joshi",   
+      "title": "The Cost of Data",   
+      "bio": "<strong>Vaidehi Joshi</strong> is a senior engineer at DEV, where she builds community and helps improve the software careers of millions. She enjoys building and breaking code, but loves creating empathetic engineering teams a whole lot more. She is the creator of basecs and baseds, two writing series exploring the fundamentals of computer science and distributed systems. She also co-hosts the Base.cs Podcast, and is a producer of the BaseCS and Byte Sized video series.",
+      "url": "https://dev.to/discussion-article"
+    },
+    {
+      "id": 1,
+      "start_time": "July 23, 2020 10:20:00 UTC",
+      "end_time": "July 23, 2020 10:40:00 UTC",
+      "speaker": "Scott Hanselman",   
+      "title": "Keynote",   
+      "bio": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation t dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation",
+      "url": "https://dev.to/discussion-article"
+    }
+  ]
+}


### PR DESCRIPTION
A couple of changes in this PR:

- The schedule section is populated now! Data is polled from `codeland_schedule.json`. 

- Schedule data is held on the page, and used to update the current talk section in conjunction with a `talk_id` specified in `codeland_now_playing.json`

Here's the flow:
- page loads, initial request made to get schedule data
- schedule section populated
- polling for schedule and talk data refreshed
