### PR TITLE
Joshpuetz/update sample data

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ _codeland.html_: code for the main CodeLand landing page
 
 _banner.html_: code for the home page hero banner 
 
-codeland_now_playing.json_: sample data format for dynamic data updates on _codeland.html_
+_codeland_now_playing.json_: sample data format for dynamic data updates on _codeland.html_
 
-codeland_schedule.json_: sample data for the programming schedule on _codeland.html_ 
+_codeland_schedule.json_: sample data for the programming schedule on _codeland.html_ 
 
 _display_ad.html_: code for the display ad/sidebar section on the homepage
 

--- a/README.md
+++ b/README.md
@@ -10,4 +10,5 @@ codeland_schedule.json_: sample data for the programming schedule on _codeland.h
 
 _display_ad.html_: code for the display ad/sidebar section on the homepage
 
+_sample_schedule.rb_: small utility to generate sample schedule json
 

--- a/codeland.html
+++ b/codeland.html
@@ -267,6 +267,11 @@
     transform: translateX(0);
   }
 
+  .codeland-schedule__event-now-playing {
+    background: green;
+  }
+
+
   @media screen and (min-width: 768px) {
 
     .codeland-schedule__event-link:hover .codeland-schedule__event-view-link {
@@ -595,6 +600,12 @@ const updateTalkInfo = talkId => {
   document.querySelector('.codeland-livestream__info-title h2').textContent = `${talkData.title} by ${talkData.speaker}`;
   document.querySelector('.codeland-livestream__speaker-info div p').innerHTML = talkData.bio;
   document.querySelector('.codeland-livestream__speaker-info div button').dataset.url = talkData.url;
+
+  var currentNowPlaying = document.querySelector('.codeland-schedule__event-now-playing')
+  if(currentNowPlaying) {
+    currentNowPlaying.classList.remove('codeland-schedule__event-now-playing');
+  };
+  document.getElementById(`talk-${talkId}`).classList.add('codeland-schedule__event-now-playing');
 };
 
 const updateScheduleInfo = scheduleData => {
@@ -608,7 +619,7 @@ const updateScheduleInfo = scheduleData => {
     var end_time = new Date(Date.parse(data.end_time));
 
     var listing = template.content.cloneNode(true);
-    listing.querySelector('.codeland-schedule__event').setAttribute("data-event-id", data.id);
+    listing.querySelector('.codeland-schedule__event').id = `talk-${data.id}`;
     listing.querySelector('.codeland-schedule__event-metadata').innerHTML = `${start_time.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })} - ${end_time.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })} `;
     listing.querySelector('.codeland-schedule__event-info h3').innerHTML = data.speaker;
     listing.querySelector('.codeland-schedule__event-title').innerHTML = data.title;
@@ -1016,7 +1027,7 @@ document.addEventListener("DOMContentLoaded", function() {
 
 <template id="schedule-entry-template">
   <a href="" class="codeland-schedule__event-link">
-    <div class="codeland-schedule__event" data-event-id="">
+    <div class="codeland-schedule__event" id="">
       <div class="codeland-schedule__event-metadata fs-s s:fs-base">
         10 AM - 10:20 AM UTC
       </div>

--- a/codeland_schedule.json
+++ b/codeland_schedule.json
@@ -1,22 +1,103 @@
 {
   "schedule": [
-    {
-      "id": 1,
-      "start_time": "July 23, 2020 10:00:00 UTC",
-      "end_time": "July 23, 2020 10:20:00 UTC",
-      "speaker": "Vaidehi Joshi",   
-      "title": "The Cost of Data",   
-      "bio": "<strong>Vaidehi Joshi</strong> is a senior engineer at DEV, where she builds community and helps improve the software careers of millions. She enjoys building and breaking code, but loves creating empathetic engineering teams a whole lot more. She is the creator of basecs and baseds, two writing series exploring the fundamentals of computer science and distributed systems. She also co-hosts the Base.cs Podcast, and is a producer of the BaseCS and Byte Sized video series.",
-      "url": "https://dev.to/discussion-article"
-    },
-    {
-      "id": 1,
-      "start_time": "July 23, 2020 10:20:00 UTC",
-      "end_time": "July 23, 2020 10:40:00 UTC",
-      "speaker": "Scott Hanselman",   
-      "title": "Keynote",   
-      "bio": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation t dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation",
-      "url": "https://dev.to/discussion-article"
-    }
+      {
+          "id": 1,
+          "start_time": "June 25, 2020 17:00:00 UTC",
+          "end_time": "June 25, 2020 17:01:00 UTC",
+          "speaker": "Vaidehi Joshi",
+          "title": "Machine Learning On The Edge",
+          "bio": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation t dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation",
+          "url": "https://dev.to/fdoxyz/speaker-discussion-132b-temp-slug-1943013?preview=a26e78ab2bd2bff858bf3f18153039330d9ff081fecdf4d62997dce268d048775b281dc39b0cf2839c0ff657f91e5eeeec19eebd4df9ee03d302d92d"
+      },
+      {
+          "id": 2,
+          "start_time": "June 25, 2020 17:01:00 UTC",
+          "end_time": "June 25, 2020 17:02:00 UTC",
+          "speaker": "Vaidehi Joshi",
+          "title": "Keynote",
+          "bio": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation t dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation",
+          "url": "https://dev.to/fdoxyz/speaker-discussion-132b-temp-slug-1943013?preview=a26e78ab2bd2bff858bf3f18153039330d9ff081fecdf4d62997dce268d048775b281dc39b0cf2839c0ff657f91e5eeeec19eebd4df9ee03d302d92d"
+      },
+      {
+          "id": 3,
+          "start_time": "June 25, 2020 17:02:00 UTC",
+          "end_time": "June 25, 2020 17:03:00 UTC",
+          "speaker": "Scott Hanselman",
+          "title": "Machine Learning On The Edge",
+          "bio": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation t dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation",
+          "url": "https://dev.to/fdoxyz/speaker-discussion-1c91-temp-slug-3619252?preview=bc7593fd6e022218ee2944d91dc69e8043429d2ee86be941a4e2a5e71b519fb7f9e018a3abebe8c30d027852febbb5cb1523358776c9284d6141a67d"
+      },
+      {
+          "id": 4,
+          "start_time": "June 25, 2020 17:03:00 UTC",
+          "end_time": "June 25, 2020 17:04:00 UTC",
+          "speaker": "Scott Hanselman",
+          "title": "The Cost of Data",
+          "bio": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation t dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation",
+          "url": "https://dev.to/fdoxyz/speaker-discussion-132b-temp-slug-1943013?preview=a26e78ab2bd2bff858bf3f18153039330d9ff081fecdf4d62997dce268d048775b281dc39b0cf2839c0ff657f91e5eeeec19eebd4df9ee03d302d92d"
+      },
+      {
+          "id": 5,
+          "start_time": "June 25, 2020 17:04:00 UTC",
+          "end_time": "June 25, 2020 17:05:00 UTC",
+          "speaker": "Vaidehi Joshi",
+          "title": "Machine Learning On The Edge",
+          "bio": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation t dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation",
+          "url": "https://dev.to/fdoxyz/speaker-discussion-1c91-temp-slug-3619252?preview=bc7593fd6e022218ee2944d91dc69e8043429d2ee86be941a4e2a5e71b519fb7f9e018a3abebe8c30d027852febbb5cb1523358776c9284d6141a67d"
+      },
+      {
+          "id": 6,
+          "start_time": "June 25, 2020 17:05:00 UTC",
+          "end_time": "June 25, 2020 17:06:00 UTC",
+          "speaker": "Scott Hanselman",
+          "title": "Machine Learning On The Edge",
+          "bio": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation t dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation",
+          "url": "https://dev.to/fdoxyz/speaker-discussion-1c91-temp-slug-3619252?preview=bc7593fd6e022218ee2944d91dc69e8043429d2ee86be941a4e2a5e71b519fb7f9e018a3abebe8c30d027852febbb5cb1523358776c9284d6141a67d"
+      },
+      {
+          "id": 7,
+          "start_time": "June 25, 2020 17:06:00 UTC",
+          "end_time": "June 25, 2020 17:07:00 UTC",
+          "speaker": "Scott Hanselman",
+          "title": "The Cost of Data",
+          "bio": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation t dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation",
+          "url": "https://dev.to/fdoxyz/speaker-discussion-132b-temp-slug-1943013?preview=a26e78ab2bd2bff858bf3f18153039330d9ff081fecdf4d62997dce268d048775b281dc39b0cf2839c0ff657f91e5eeeec19eebd4df9ee03d302d92d"
+      },
+      {
+          "id": 8,
+          "start_time": "June 25, 2020 17:07:00 UTC",
+          "end_time": "June 25, 2020 17:08:00 UTC",
+          "speaker": "Sangeetha KP",
+          "title": "Machine Learning On The Edge",
+          "bio": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation t dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation",
+          "url": "https://dev.to/fdoxyz/speaker-discussion-132b-temp-slug-1943013?preview=a26e78ab2bd2bff858bf3f18153039330d9ff081fecdf4d62997dce268d048775b281dc39b0cf2839c0ff657f91e5eeeec19eebd4df9ee03d302d92d"
+      },
+      {
+          "id": 9,
+          "start_time": "June 25, 2020 17:08:00 UTC",
+          "end_time": "June 25, 2020 17:09:00 UTC",
+          "speaker": "Scott Hanselman",
+          "title": "Machine Learning On The Edge",
+          "bio": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation t dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation",
+          "url": "https://dev.to/fdoxyz/speaker-discussion-1c91-temp-slug-3619252?preview=bc7593fd6e022218ee2944d91dc69e8043429d2ee86be941a4e2a5e71b519fb7f9e018a3abebe8c30d027852febbb5cb1523358776c9284d6141a67d"
+      },
+      {
+          "id": 10,
+          "start_time": "June 25, 2020 17:09:00 UTC",
+          "end_time": "June 25, 2020 17:10:00 UTC",
+          "speaker": "Scott Hanselman",
+          "title": "Keynote",
+          "bio": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation t dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation",
+          "url": "https://dev.to/fdoxyz/speaker-discussion-1c91-temp-slug-3619252?preview=bc7593fd6e022218ee2944d91dc69e8043429d2ee86be941a4e2a5e71b519fb7f9e018a3abebe8c30d027852febbb5cb1523358776c9284d6141a67d"
+      },
+      {
+          "id": 11,
+          "start_time": "June 25, 2020 17:10:00 UTC",
+          "end_time": "June 25, 2020 17:11:00 UTC",
+          "speaker": "Sangeetha KP",
+          "title": "Machine Learning On The Edge",
+          "bio": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation t dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation",
+          "url": "https://dev.to/fdoxyz/speaker-discussion-1c91-temp-slug-3619252?preview=bc7593fd6e022218ee2944d91dc69e8043429d2ee86be941a4e2a5e71b519fb7f9e018a3abebe8c30d027852febbb5cb1523358776c9284d6141a67d"
+      }
   ]
 }

--- a/sample_schedule.rb
+++ b/sample_schedule.rb
@@ -1,0 +1,48 @@
+require 'date'
+require 'json'
+
+class SampleScheduleGenerator
+  LOREM_IPSUM = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation t dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation'.freeze
+  SPEAKERS = ['Scott Hanselman', 'Vaidehi Joshi', 'Sangeetha KP'].freeze
+  TITLES = ['Keynote', 'The Cost of Data', 'Machine Learning On The Edge'].freeze
+  URLS = ['https://dev.to/fdoxyz/speaker-discussion-1c91-temp-slug-3619252?preview=bc7593fd6e022218ee2944d91dc69e8043429d2ee86be941a4e2a5e71b519fb7f9e018a3abebe8c30d027852febbb5cb1523358776c9284d6141a67d', 
+    'https://dev.to/fdoxyz/speaker-discussion-132b-temp-slug-1943013?preview=a26e78ab2bd2bff858bf3f18153039330d9ff081fecdf4d62997dce268d048775b281dc39b0cf2839c0ff657f91e5eeeec19eebd4df9ee03d302d92d'].freeze
+
+  def initialize(start_time_string, end_time_string)
+    @start_time = DateTime.parse(start_time_string).to_time.utc
+    @end_time = DateTime.parse(end_time_string).to_time.utc
+  end
+
+  # take a start and end date/time
+  # iterate over them in 1 minute intervals, rotating through presenters and talks
+  # output json
+
+  def generate
+    schedule = []
+    counter = 0
+
+    (@start_time.to_i .. @end_time.to_i).step(60) do |time|
+      counter += 1
+      schedule << create_talk_hash(counter, time, time + 60)
+    end
+
+    {schedule: schedule}.to_json
+  end
+
+  def create_talk_hash(id, start_time, end_time)
+    {
+      id: id,
+      start_time: Time.at(start_time).utc.strftime('%B %-d, %Y %H:%M:%S %Z'),
+      end_time: Time.at(end_time).utc.strftime('%B %-d, %Y %H:%M:%S %Z'),
+      speaker: SPEAKERS.sample,
+      title: TITLES.sample,
+      bio: LOREM_IPSUM,
+      url: URLS.sample
+    }
+  end
+
+
+end
+
+puts SampleScheduleGenerator.new("June 25, 2020 17:00:00 UTC", "June 25, 2020 17:10:00 UTC").generate
+


### PR DESCRIPTION
Added a small ruby utility to create sample schedule data for a time range (and popped data for a dry run into the `codeland_schedule.json` file.

Also added (ugly) highlighting to the schedule of the currently playing talk. Let me know how this can look better @lisasy !

<img width="1429" alt="codeland_-_DEV_local__Community_👩💻👨💻" src="https://user-images.githubusercontent.com/37842/85632927-da4d9800-b63d-11ea-8b3d-a4bb60e4d983.png">
