### PR TITLE
Support 'sponsor'

### DIFF
--- a/codeland.html
+++ b/codeland.html
@@ -621,6 +621,13 @@ const updateTalkInfo = () => {
     document.querySelector('.codeland-livestream__speaker-info div p').innerHTML = talkData.bio;
     document.querySelector('.codeland-livestream__speaker-info div button').dataset.url = talkData.url;
 
+
+    if (talkData.sponsor) {
+      document.querySelector('.codeland-livestream__speaker-info__footer button').textContent = 'Learn more';
+    } else {
+      document.querySelector('.codeland-livestream__speaker-info__footer button').textContent = 'See discussion';
+    }
+
     var currentNowPlaying = document.querySelector('.codeland-schedule__event-now-playing')
     if(currentNowPlaying) {
       currentNowPlaying.classList.remove('codeland-schedule__event-now-playing');
@@ -811,17 +818,10 @@ document.addEventListener("DOMContentLoaded", function() {
       <aside class="codeland-livestream__speaker-info crayons-card">
         <div class="crayons-card__body">
           <p class="mb-4 fs-base">
-          <strong>Vaidehi Joshi</strong> is a senior engineer at DEV, where she builds community
-            and helps improve the software careers of millions. She enjoys building
-            and breaking code, but loves creating empathetic engineering teams a
-            whole lot more. She is the creator of basecs and baseds, two writing
-            series exploring the fundamentals of computer science and distributed
-            systems. She also co-hosts the Base.cs Podcast, and is a producer of the
-            BaseCS and Byte Sized video series.
+            Welcome to CodeLand: Distributed 2020! The show will start soon, get ready!
           </p>
           <div class="codeland-livestream__speaker-info__footer">
             <button class="crayons-btn crayons-btn--secondary w-100" type="button" data-url="">
-              See discussion
             </button>
           </div>
         </div>
@@ -833,11 +833,10 @@ document.addEventListener("DOMContentLoaded", function() {
           </span>
           <div class="codeland-livestream__info-title">
             <h2>
-              The Cost of Data by Vaidehi Joshi
+              Welcome to CodeLand: Distributed 2020!
             </h2>
             <h2 class="codeland-livestream__info-helper fw-normal">
               <span>
-                View Info
               </span>
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="32" height="32"><path fill="none" d="M0 0h24v24H0z"/><path d="M16.172 11l-5.364-5.364 1.414-1.414L20 12l-7.778 7.778-1.414-1.414L16.172 13H4v-2z"/></svg>
             </h2>

--- a/codeland.html
+++ b/codeland.html
@@ -171,7 +171,7 @@
     bottom: 0;
     left: 0;
     right: 0;
-    display: flex;
+    display: none;
     align-items: center;
     justify-content: center;
     box-sizing: border-box;
@@ -620,12 +620,15 @@ const updateTalkInfo = () => {
     document.querySelector('.codeland-livestream__info-title h2').textContent = `${talkData.title} by ${talkData.speaker}`;
     document.querySelector('.codeland-livestream__speaker-info div p').innerHTML = talkData.bio;
     document.querySelector('.codeland-livestream__speaker-info div button').dataset.url = talkData.url;
+    document.querySelector('.codeland-livestream__speaker-info__footer').style.display = "flex";
 
 
     if (talkData.sponsor) {
       document.querySelector('.codeland-livestream__speaker-info__footer button').textContent = 'Learn more';
+      document.querySelector('.codeland-livestream__speaker-info div button').dataset.url = talkData.url;
     } else {
       document.querySelector('.codeland-livestream__speaker-info__footer button').textContent = 'See discussion';
+      document.querySelector('.codeland-livestream__speaker-info div button').dataset.url = `${talkData.url}#comments`;
     }
 
     var currentNowPlaying = document.querySelector('.codeland-schedule__event-now-playing')
@@ -818,7 +821,7 @@ document.addEventListener("DOMContentLoaded", function() {
       <aside class="codeland-livestream__speaker-info crayons-card">
         <div class="crayons-card__body">
           <p class="mb-4 fs-base">
-            Welcome to CodeLand: Distributed 2020! The show will start soon, get ready!
+            Welcome to CodeLand: Distributed 2020!
           </p>
           <div class="codeland-livestream__speaker-info__footer">
             <button class="crayons-btn crayons-btn--secondary w-100" type="button" data-url="">
@@ -1177,7 +1180,7 @@ document.addEventListener("DOMContentLoaded", function() {
   // EventListener for Main CTA in Livestream section
   livestreamButt.addEventListener('click', () => {
     presentSidecar(
-      `${livestreamButt.dataset.url}#comments`,
+      livestreamButt.dataset.url,
       'Discussion Article',
       'Find all these articles in <a href="/t/codeland" target="_blank">#codeland</a>'
     );


### PR DESCRIPTION
Add support for a `sponsor` tag in schedule data. When `"sample: true` is found in a talk schedule block, the text of the speaker block call to action will change from `See Discussion` to `Learn More`

<img width="372" alt="codeland_-_DEV_local__Community_👩💻👨💻" src="https://user-images.githubusercontent.com/37842/86282476-ed63e900-bba4-11ea-9d41-68ec64dfed68.png">

(@fdoxyz: any thoughts on what to do about the click handler that opens the sidecar? Change the text popped at the top of it via a template?
