### PR TITLE
Tweaks height & margin to fix bottom issue in sidecar

### DIFF
--- a/codeland.html
+++ b/codeland.html
@@ -613,10 +613,14 @@
   }
 
   .codeland-sidecar > iframe {
-    height: 100%;
+    height: calc(100vh - 140px);
     border: none;
     box-shadow: 0 -1px 1px var(--header-shadow);
     width: 100vw;
+  }
+
+  body.static-navbar-config .codeland-sidecar {
+    margin-top: 56px;
   }
 
   .codeland-sidecar > header {


### PR DESCRIPTION
Tweaks height & margin to fix bottom issue in sidecar. Also takes into account the static top nav option

Turns this

<img width="1203" alt="Screen Shot 2020-07-20 at 22 03 38" src="https://user-images.githubusercontent.com/6045239/88011599-f0336900-cad4-11ea-8b4a-02facf0743d9.png">


Into this:

<img width="1214" alt="Screen Shot 2020-07-20 at 22 03 48" src="https://user-images.githubusercontent.com/6045239/88011603-f45f8680-cad4-11ea-9843-a9a78586fdbf.png">