### PR TITLE
Adds #sidecar hash for tracking the back action in mobile

### DIFF
--- a/codeland.html
+++ b/codeland.html
@@ -810,7 +810,7 @@ const updateScheduleInfo = scheduleData => {
     } else {
       listing.querySelector('.codeland-schedule__event-metadata').innerHTML = `${start_time.toTimeString().replace(/.*(\d{2}:\d{2}):\d{2}.*/, "$1")} - ${end_time.toTimeString().replace(/.*(\d{2}:\d{2}):\d{2}.*\((.*)\)/, "$1 $2")} `;
     }
-    
+
     listing.querySelector('.codeland-schedule__event-info h3').innerHTML = data.speaker;
     listing.querySelector('.codeland-schedule__event-title').innerHTML = data.title;
     listing.querySelector('.codeland-schedule__event-speaker-bio').innerHTML = data.bio;
@@ -1369,6 +1369,8 @@ document.addEventListener("DOMContentLoaded", function() {
       sidecarTitle.innerHTML = title;
       sidecarSubtitle.innerHTML = subtitle;
     }
+
+    window.history.pushState("", document.title, '#sidecar');
   }
 
   // EventListener for Main CTA in Livestream section
@@ -1394,6 +1396,7 @@ document.addEventListener("DOMContentLoaded", function() {
   closeButt.addEventListener('click', () => {
     if (sidecarDiv.classList.contains('showing')) {
       sidecarDiv.classList.toggle('showing');
+      history.replaceState('', document.title, '/codeland');
     }
   });
 
@@ -1422,6 +1425,16 @@ document.addEventListener("DOMContentLoaded", function() {
   });
   document.querySelectorAll('.codeland-sponsors__logo-wrapper').forEach(link => {
     link.addEventListener('click', sponsorBoothClick);
+  });
+
+  window.addEventListener("hashchange", function(e) {
+    const regex = /#sidecar/;
+    if (e.oldURL.match(regex) != null && e.newURL.match(regex) == null) {
+      // When the #sidecar hash is removed it means the user went "back"
+      // Most likely to happen in mobile: This overrides the back button feature
+      sidecarDiv.classList.remove('showing');
+      history.replaceState('', document.title, '/codeland');
+    }
   });
 
 


### PR DESCRIPTION
This one adds `#sidecar` hash to the URL when toggling the sidecar in order to track "back button" functionality in mobile.

The current problem is that the sidecar takes over the entire screen (small screens), so the "natural action" is to hit the "back button" on Android devices to dismiss it. This PR implements an override for this.

This doesn't fix the issue on iOS. I haven't found a way around this yet.

