### PR TITLE
CSV to JSON schedule converter script

### DIFF
--- a/schedule_csv_to_json.rb
+++ b/schedule_csv_to_json.rb
@@ -1,0 +1,31 @@
+require 'csv'
+require 'json'
+require 'active_support/time'
+
+# This script reads from a CSV file named `input_schedule.csv` and writes to
+# a JSON file with the schedule data embedded named `output_schedule.json`
+
+rows = CSV.new(File.read('input_schedule.csv')).read
+
+data = []
+keys = rows.shift
+rows.each do |row|
+  block = {}
+  row.each_with_index do |value, index|
+    key = keys[index]
+    if value.nil?
+      # This should not happen -> CSV file should be correct!
+      block[key] = ''
+    elsif key == 'start_time' || key == 'end_time'
+      new_date = Time.current
+      hour, minute, second = value.split(':').map(&:strip).map(&:to_i)
+      parsed_date = new_date.change(hour: hour || 0, min: minute || 0, sec: second || 0)
+      block[key] = parsed_date.utc.strftime('%B %-d, %Y %H:%M:%S %Z')
+    else
+      block[key] = value
+    end
+  end
+  data << block
+end
+
+File.write('output_schedule.json', { schedule: data }.to_json)

--- a/schedule_csv_to_json.rb
+++ b/schedule_csv_to_json.rb
@@ -5,27 +5,36 @@ require 'active_support/time'
 # This script reads from a CSV file named `input_schedule.csv` and writes to
 # a JSON file with the schedule data embedded named `output_schedule.json`
 
-rows = CSV.new(File.read('input_schedule.csv')).read
+rows = CSV.new(File.read('schedule.csv')).read
 
 data = []
-keys = rows.shift
-rows.each do |row|
+keys = rows.shift.map(&:strip)
+rows.each_with_index do |row, row_index|
   block = {}
   row.each_with_index do |value, index|
     key = keys[index]
-    if value.nil?
-      # This should not happen -> CSV file should be correct!
-      block[key] = ''
-    elsif key == 'start_time' || key == 'end_time'
-      new_date = Time.current
-      hour, minute, second = value.split(':').map(&:strip).map(&:to_i)
-      parsed_date = new_date.change(hour: hour || 0, min: minute || 0, sec: second || 0)
+
+    # These are keys we don't use in our JSON
+    next if ['minutes', 'seconds', 'delay_min', 'delay_sec'].include?(key)
+
+    if key == 'start_time'
+      new_date = DateTime.parse('2020-07-23 00:00:00 EDT').to_time
+      date_str = value.delete_suffix(' PM').delete_suffix(' AM')
+      hour, minute, second = date_str.split(':').map(&:strip).map(&:to_i)
+      parsed_date = new_date + hour.hours + minute.minutes + second.seconds
       block[key] = parsed_date.utc.strftime('%B %-d, %Y %H:%M:%S %Z')
+
+      # The end_time is added to the 'previous block' (using the current 'start_time')
+      data[row_index-1]['end_time'] = block[key] if row_index > 0
+    elsif key == 'sponsor'
+      block[key] = (value == 'TRUE')
     else
-      block[key] = value
+      block[key] = value.to_s
     end
   end
   data << block
 end
 
-File.write('output_schedule.json', { schedule: data }.to_json)
+data.pop # Last element is not needed ("THE END")
+
+File.write('schedule.json', { schedule: data }.to_json)

--- a/schedule_csv_to_json.rb
+++ b/schedule_csv_to_json.rb
@@ -19,9 +19,14 @@ rows.each_with_index do |row, row_index|
 
     if key == 'start_time'
       new_date = DateTime.parse('2020-07-23 00:00:00 EDT').to_time
+      should_add_12h = value.include?('PM')
       date_str = value.delete_suffix(' PM').delete_suffix(' AM')
       hour, minute, second = date_str.split(':').map(&:strip).map(&:to_i)
       parsed_date = new_date + hour.hours + minute.minutes + second.seconds
+
+      # This offsets the 'PM' times but 12:00:00 PM is noon so it doesn't need
+      # the +12h offset, just an ugly case that requires this extra check :@
+      parsed_date = parsed_date + 12.hours if should_add_12h && hour < 12
       block[key] = parsed_date.utc.strftime('%B %-d, %Y %H:%M:%S %Z')
 
       # The end_time is added to the 'previous block' (using the current 'start_time')

--- a/schedule_csv_to_json.rb
+++ b/schedule_csv_to_json.rb
@@ -15,7 +15,7 @@ rows.each_with_index do |row, row_index|
     key = keys[index]
 
     # These are keys we don't use in our JSON
-    next if ['minutes', 'seconds', 'delay_min', 'delay_sec'].include?(key)
+    next if ['minutes', 'seconds', 'delay_minutes', 'delay_seconds'].include?(key)
 
     if key == 'start_time'
       new_date = DateTime.parse('2020-07-23 00:00:00 EDT').to_time

--- a/schedule_update_steps.md
+++ b/schedule_update_steps.md
@@ -1,14 +1,14 @@
 ## How to update the schedule "on the fly"
 
-Go to the [CodeLand Master Production](https://docs.google.com/spreadsheets/d/1kQNQ67qZKdeDRXgExQYhbkTfKjqInQqnUjl6NL_Q6qU/edit#gid=1142373351) spreadsheet. The columns __minutes__ & __seconds__ represent the __duration__ of each speaker/sponsor. The columns __delay_min__ & __delay_sec__ are the ones that should be used in case we encounter any delays along the way.
+Go to the [CodeLand Master Production](https://docs.google.com/spreadsheets/d/1kQNQ67qZKdeDRXgExQYhbkTfKjqInQqnUjl6NL_Q6qU/edit#gid=1142373351) spreadsheet. The columns __delay_minutes__ & __delay_seconds__ should be used in case we encounter any delays along the way.
 
 Example:
 
-The Live Speaker Panel with id `114` had some trouble getting started and we're now 3 minutes behind of schedule. We should add a 3 minute delay to that row (simple 3 added to __delay_min__). This will cause all other talks downstream to update their times in cascade.
+The Live Speaker Panel with id `114` had some trouble getting started and we're now 3 minutes behind schedule. We should add a 3 minute delay to that row (simply set 3 to __delay_minutes__ column). Logically this can be seen as "the block with id `114` introduced a 3 minute delay". This will cause all other talks downstream to update their times in cascade.
 
 ### What next?
 
 1. `File` > `Download` > `.csv, current sheet`
 1. Rename the CSV file to `schedule.csv` and place it in this directory
 1. Parse the CSV into JSON using the script `ruby schedule_csv_to_json.rb`
-1. Copy `schedule.json` contents and edit the Codeland Schedule page in [https://dev.to/internal/pages](https://dev.to/internal/pages)
+1. Copy `schedule.json` contents and edit the Codeland Schedule page in [https://dev.to/internal/pages/163/edit](https://dev.to/internal/pages/163/edit)

--- a/schedule_update_steps.md
+++ b/schedule_update_steps.md
@@ -1,0 +1,14 @@
+## How to update the schedule "on the fly"
+
+Go to the [CodeLand Master Production](https://docs.google.com/spreadsheets/d/1kQNQ67qZKdeDRXgExQYhbkTfKjqInQqnUjl6NL_Q6qU/edit#gid=1142373351) spreadsheet. The columns __minutes__ & __seconds__ represent the __duration__ of each speaker/sponsor. The columns __delay_min__ & __delay_sec__ are the ones that should be used in case we encounter any delays along the way.
+
+Example:
+
+The Live Speaker Panel with id `114` had some trouble getting started and we're now 3 minutes behind of schedule. We should add a 3 minute delay to that row (simple 3 added to __delay_min__). This will cause all other talks downstream to update their times in cascade.
+
+### What next?
+
+1. `File` > `Download` > `.csv, current sheet`
+1. Rename the CSV file to `schedule.csv` and place it in this directory
+1. Parse the CSV into JSON using the script `ruby schedule_csv_to_json.rb`
+1. Copy `schedule.json` contents and edit the Codeland Schedule page in [https://dev.to/internal/pages](https://dev.to/internal/pages)


### PR DESCRIPTION
First POC for a CSV -> JSON schedule converter

`start_time` & `end_time` need to come in `HH:MM:SS` format, there's no need to worry about having the full ISO date format