### PR TITLE
disable sidecar on empty/null links

### DIFF
--- a/codeland.html
+++ b/codeland.html
@@ -1496,6 +1496,10 @@ document.addEventListener("DOMContentLoaded", function() {
   let articleCommentCount = -1;
 
   const presentSidecar = (url, title, subtitle, watchComments = true) => {
+    if (url === window.location.href) {
+      return;
+    }
+
     if (!sidecarDiv.classList.contains('showing')) {
       sidecarDiv.classList.toggle('showing');
     }


### PR DESCRIPTION
Tiny change, when looking doing `element.href` and the href is an empty string ("") JS gives us `window.location.href` instead of an empty string.

Merging right away but wanted to create the PR for visibility :)