### PR TITLE
Don't add click event to schedule listings without URLS

### DIFF
--- a/codeland.html
+++ b/codeland.html
@@ -1023,7 +1023,7 @@ const updateScheduleInfo = scheduleData => {
   });
 
   // After the schedule is updated make sure they have an Event Listener
-  document.querySelectorAll('.codeland-schedule__event-link').forEach(link => {
+  document.querySelectorAll('.codeland-schedule__event-link:not(.codeland-schedule__event-link__no-hover)').forEach(link => {
     link.addEventListener('click', scheduleClick);
   });
 }


### PR DESCRIPTION
Don't add the click listener in the schedule panel for listings without a URL (such as: emcee announcements).

(For some reason I can't quite figure out, this doesn't work on the first load of the page, but only after the first 1 minute schedule refresh interval 🤔 )